### PR TITLE
Pass indices of elementwise ops and params into solver

### DIFF
--- a/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
+++ b/tensorflow/compiler/xla/service/spmd/auto_sharding.cc
@@ -7,8 +7,6 @@
 #include "tensorflow/compiler/xla/service/hlo_ordering.h"
 #include "tensorflow/compiler/xla/service/hlo_sharding_util.h"
 #include "tensorflow/compiler/xla/service/spmd/auto_sharding_strategy.h"
-#include <string.h>
-#include <typeinfo>
 
 namespace xla {
 namespace spmd {


### PR DESCRIPTION
Pass indices of elementwise ops and params into solver. Additionally prints out the operators in the HLO graph for debugging information.